### PR TITLE
Add libpq-dev to base image

### DIFF
--- a/docker/kraken-base-image.Dockerfile
+++ b/docker/kraken-base-image.Dockerfile
@@ -25,7 +25,7 @@ RUN ( curl -fsSL https://deb.nodesource.com/setup_18.x | bash - )
 
 RUN : \
     && apt-get update \
-    && apt-get install -y docker.io nodejs graphviz unzip \
+    && apt-get install -y docker.io nodejs graphviz unzip libpq-dev \
     #
     # Rust
     #

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ Aside from the `develop` tag, exact image versions can be pinned based on `git t
 | Kubectl | apt-get (`apt.kubernetes.io`) | latest |
 | libffi | apt-get | latest |
 | libssl | apt-get | latest |
+| libpq-dev | apt-get | latest |
 | llvm | apt-get | latest |
 | manifest-tool | [Releases](https://github.com/estesp/manifest-tool/releases) | 2.0.4 |
 | NodeJS | apt-get (`deb.nodesource.com/setup_18.x`) | latest (18) |


### PR DESCRIPTION
Libpq-dev is required to run diesel (an ORM) tests.