### PR TITLE
update Poetry and Slap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/doc
 #
 RUN : \
     && python -m pip install pipx -v \
-    && pipx install poetry==1.3.1 \
-    && pipx install slap-cli==1.6.30 \
+    && pipx install poetry==1.3.2 \
+    && pipx install slap-cli==1.6.33 \
     && pipx install kraken-wrapper==0.2.0 \
     && pipx install proxy.py==2.4.3 && pipx inject proxy.py certifi \
     && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==6.6.0 \

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ is built from various Ubuntu starting images.
 | NodeJS | apt-get (`deb.nodesource.com/setup_18.x`) | latest (18) |
 | Pipx | Pip (Python 3.10) | latest |
 | pkg-config | apt-get | latest |
-| Poetry | Pipx (Python 3.10) | 1.3.1 |
+| Poetry | Pipx (Python 3.10) | 1.3.2 |
 | protobuf-compiler | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1 |
 | proxy.py | Pipx (Python 3.10) | 2.4.3 |
 | pyenv | [pyenv-installer](https://github.com/pyenv/pyenv-installer) | latest |
@@ -56,7 +56,7 @@ is built from various Ubuntu starting images.
 | Rust | Rustup | latest |
 | Rustup | rustup.rs | latest |
 | sccache | [Github releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.3.0 |
-| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.6.30 |
+| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.6.33 |
 | Terraform | Hashicorp releases | 1.3.2 |
 | wget | apt-get | latest |
 | [yq](https://mikefarah.gitbook.io/yq/) | [Github releases](https://github.com/mikefarah/yq/releases) | 4.30.1 |


### PR DESCRIPTION
Updates Poetry to `1.3.2` and Slap to `1.6.33`.

We need these to be updated at the same time as the latest version of Poetry will complain about malformed `tool.poetry.extras` sections that Slap permits (only dependency names for Poetry, but Slap permits version constraints), but only Slap 1.6.33 introduces support for Poetry "Groups" which also permit version constraints.