### PR TITLE
Add cargo-llvm-cov to Rust tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN : \
 RUN : \
     && cargo install cargo-deny \
     && cargo install sqlx-cli \
-    && cargo install install cargo-llvm-cov
+    && cargo install cargo-llvm-cov
 
 # 
 # Protobuf tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,8 @@ RUN : \
 #
 RUN : \
     && cargo install cargo-deny \
-    && cargo install sqlx-cli
+    && cargo install sqlx-cli \
+    && cargo install install cargo-llvm-cov
 
 # 
 # Protobuf tools

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ is built from various Ubuntu starting images.
 | buf | [GitHub releases](https://github.com/bufbuild/buf/releases) | 1.17.0 |
 | build-essential | apt-get | latest |
 | cargo-deny | cargo | latest |
+| cargo-llvm-cov | cargo | latest |
 | clang | apt-get | latest |
 | cmake | apt-get | latest |
 | cURL | apt-get | latest |


### PR DESCRIPTION
For test coverage reporting, Rust has [coverage instrumentation built into the compiler](https://doc.rust-lang.org/rustc/instrument-coverage.html). [`cargo-llvm-cov`](https://doc.rust-lang.org/rustc/instrument-coverage.html) wraps usage of this and adds it as a cargo command.