### PR TITLE
Include the Nix daemon in the Kraken base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE
 ENV DEBIAN_FRONTEND noninteractive
 RUN : \
     && apt-get update \
-    && apt-get install -y curl git wget libssl-dev libffi-dev llvm clang gcc g++ pkg-config build-essential jq \
+    && apt-get install -y curl git wget libssl-dev libffi-dev llvm clang gcc g++ pkg-config build-essential jq sudo \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Install Python versions with deadsnakes.
@@ -124,3 +124,9 @@ RUN : \
     && pipx install proxy.py==2.4.3 && pipx inject proxy.py certifi \
     && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==8.1.0 \
     && rm -rf ~/.cache/pip
+
+#
+# Nix
+#
+RUN : \
+    && sh <(curl -L https://nixos.org/nix/install) --daemon


### PR DESCRIPTION
This won't lead to a _fully_ working installation of Nix, but it's one command (`source $HOME/.nix-profile/etc/profile.d/nix-daemon.sh`) away from this. We can have kraken-hs set this up along with e.g. Nix internal auth, Nix caching for you automatically on application of some flag.