### PR TITLE
Use buffrs 0.6.1 - better tracing for buffrs login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN : \
 # Protobuf tools
 #
 RUN : \
-    && cargo install buffrs --version 0.6.0 \
+    && cargo install buffrs --version 0.6.1 \
     && BIN="/usr/bin"  \
     && VERSION="1.17.0"  \
     && curl -sSL \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ is built from various Ubuntu starting images.
 | ansible | Pipx (Python 3.10) | 8.1.0 |
 | ansible-base | Pipx (Python 3.10) | 2.10.17 |
 | buf | [GitHub releases](https://github.com/bufbuild/buf/releases) | 1.17.0 |
-| buffrs | cargo | 0.6.0 |
+| buffrs | cargo | 0.6.1 |
 | build-essential | apt-get | latest |
 | BuildKit | GitHub Releases | 0.12.2 |
 | cargo-deny | cargo | latest |


### PR DESCRIPTION
This change should give us more detailed logging for the failing buffrs login task on CI (which is working locally)