### PR TITLE
Update slap and kraken wrapper versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,8 +122,8 @@ RUN : \
     && python -m pip install pipx -v \
     && pipx install poetry==1.6.0 \
     && pipx install pdm==2.8.2 \
-    && pipx install slap-cli==1.10.2 \
-    && pipx install kraken-wrapper==0.31.0 \
+    && pipx install slap-cli==1.10.3 \
+    && pipx install kraken-wrapper==0.31.4 \
     && pipx install proxy.py==2.4.3 && pipx inject proxy.py certifi \
     && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==8.1.0 \
     && rm -rf ~/.cache/pip

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ is built from various Ubuntu starting images.
 | grcov | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py)) | 0.8.11 |
 | jq | apt-get | latest |
 | Helm | get-helm-3 | latest |
-| kraken-wrapper | Pipx (Python 3.10) | 0.31.0 |
+| kraken-wrapper | Pipx (Python 3.10) | 0.31.4 |
 | Kubectl | apt-get (`apt.kubernetes.io`) | latest |
 | lcov | apt-get | latest
 | libffi | apt-get | latest |
@@ -64,7 +64,7 @@ is built from various Ubuntu starting images.
 | Rustup | rustup.rs | latest |
 | rustfmt | rustup | nightly (additionally) |
 | sccache | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.5.2 |
-| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.10.2 |
+| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.10.3 |
 | sqlx-cli | cargo | latest |
 | Terraform | Hashicorp releases | 1.3.2 |
 | wget | apt-get | latest |


### PR DESCRIPTION
Should fix the `slap venv -ac` build error under `python.build`, and released features from 0.30.1 to 0.30.4 in kraken-wrapper