### PR TITLE
Big round of version upgrades

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,8 +76,16 @@ jobs:
       - name: Install kraken-wrapper
         run: pip install --upgrade kraken-wrapper
 
-      - name: Debug
-        run: pwd; ls -la
+      # See https://github.com/orgs/community/discussions/42856#discussioncomment-7678867
+      - name: Adding required env vars for caching Docker build
+        uses: actions/github-script@v7
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env['ACTIONS_CACHE_URL'])
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          # core.exportVariable('ACTIONS_RUNTIME_URL', process.env['ACTIONS_RUNTIME_URL'])
 
       - run: |
           krakenw r -s -v

--- a/.kraken.py
+++ b/.kraken.py
@@ -58,8 +58,8 @@ def build_kraken_image(base_image: str, platform: str) -> tuple[Task, list[str]]
         auth=get_docker_auth(),
         tags=tags,
         platform=platform,
-        build_args={"CACHE_BUSTER": str(time.time()), "BASE_IMAGE": base_image},s
-        secrets={"MINIO_ADMIN_PASSWORD": os.environ["MINIO_ADMIN_PASSWORD"]},
+        build_args={"CACHE_BUSTER": str(time.time()), "BASE_IMAGE": base_image, "ACTIONS_CACHE_URL": os.environ["ACTIONS_CACHE_URL"]},
+        secrets={"ACTIONS_RUNTIME_TOKEN": os.environ["ACTIONS_RUNTIME_TOKEN"]},
         cache_repo=f"{prefix}:{base_image.replace(':', '_')}-cache",
         push=True,
         load=False,

--- a/.kraken.py
+++ b/.kraken.py
@@ -58,7 +58,8 @@ def build_kraken_image(base_image: str, platform: str) -> tuple[Task, list[str]]
         auth=get_docker_auth(),
         tags=tags,
         platform=platform,
-        build_args={"CACHE_BUSTER": str(time.time()), "BASE_IMAGE": base_image},
+        build_args={"CACHE_BUSTER": str(time.time()), "BASE_IMAGE": base_image},s
+        secrets={"MINIO_ADMIN_PASSWORD": os.environ["MINIO_ADMIN_PASSWORD"]},
         cache_repo=f"{prefix}:{base_image.replace(':', '_')}-cache",
         push=True,
         load=False,

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,31 +17,21 @@ RUN : \
     && apt-get install -y software-properties-common --no-install-recommends \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt update \
-    # Install Python 3.6 - 3.10, and Pip for the system default Python version.
-    # Note that deadsnakes does not provide Python 3.6 on 22.04.
-    &&  if [ "${BASE_IMAGE}" == "ubuntu:22.04" ]; then \
-            apt-get install -y python{3.7,3.8,3.9,3.10,3.11}{,-venv,-dev} --no-install-recommends; \
-        else \
-            apt-get install -y python{3.6,3.7,3.8,3.9,3.10,3.11}{,-venv,-dev} --no-install-recommends; \
-        fi \
+    && apt-get install -y python{3.8,3.9,3.10,3.11,3.12}{,-venv,-dev} --no-install-recommends \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 RUN : \
     # Install Pip for all other Python versions.
     && set -x \
-    # NOTE(NiklasRosenstein): get-pip.py is not supported for Python 3.6. And we don't have Python3.6 on 22.04.
-    && if [ "${BASE_IMAGE}" != "ubuntu:18.04" ] && [ "${BASE_IMAGE}" != "ubuntu:22.04" ]; then python3.6 -m ensurepip && python3.6 -m pip install --upgrade pip; fi \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.7 - \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.8 - \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 - \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 - \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 - \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 - \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 - \
     # Install Python 3.10 as the default version.
     && ln -svf $(which python3.10) /usr/bin/python \
     && ln -svf $(which python3.10) /usr/bin/python3
 
-ENV PYENV_ROOT /root/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 ENV PATH="$PATH:/root/.cargo/bin:/root/.local/bin"
 
 COPY formulae /tmp/formulae
@@ -61,11 +51,7 @@ RUN : \
     #
     # more APT packages
     #
-    &&  if [ "${BASE_IMAGE}" == "ubuntu:18.04" ]; then \
-            ( curl -fsSL https://deb.nodesource.com/setup_16.x | bash - ); \
-        else \
-            ( curl -fsSL https://deb.nodesource.com/setup_18.x | bash - ); \
-        fi \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get update \
     && apt-get install -y docker.io nodejs graphviz unzip lcov git-lfs \
     #
@@ -77,10 +63,6 @@ RUN : \
     # helm
     #
     && ( curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash ) \
-    #
-    # Pyenv
-    #
-    && curl https://pyenv.run | bash \
     #
     # [cleanup]
     #
@@ -120,13 +102,12 @@ RUN : \
 # Python tools
 #
 RUN : \
-    && python -m pip install pipx -v \
-    && pipx install poetry==1.6.0 \
-    && pipx install pdm==2.8.2 \
-    && pipx install slap-cli==1.10.3 \
+    && python -m pip install pipx==1.3.3 -v \
+    && pipx install poetry==1.7.1 \
+    && pipx install pdm==2.11.1 \
+    && pipx install slap-cli==1.11.1 \
     && pipx install kraken-wrapper==0.32.4 \
-    && pipx install proxy.py==2.4.3 && pipx inject proxy.py certifi \
-    && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==8.1.0 \
+    && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==9.1.0 \
     && rm -rf ~/.cache/pip
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ RUN --mount=type=secret,id=MINIO_ADMIN_PASSWORD : \
     && ( SCCACHE_BUCKET=sccache \
         SCCACHE_ENDPOINT=http://95.217.239.127:9000 \
         SCCACHE_S3_USE_SSL=false \
+        SCCACHE_REGION=us-east-1 \
         AWS_ACCESS_KEY_ID=admin \
         AWS_SECRET_ACCESS_KEY=$(cat /run/secrets/MINIO_ADMIN_PASSWORD) \
         sccache --start-server \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,16 +78,16 @@ COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/doc
 # Rust tools
 #
 RUN : \
-    && cargo install cargo-deny \
-    && cargo install cargo-semver-checks \
-    && cargo install sqlx-cli \
-    && cargo install cargo-llvm-cov \
-    && cargo install cargo-hack \
     && rustup toolchain install 1.73.0 \
-    && rustup component add rustfmt --toolchain 1.73.0
+    && rustup component add rustfmt --toolchain 1.73.0 \
+    && cargo install cargo-deny --version 0.14.3 \
+    && cargo install cargo-semver-checks --version 0.26.0 \
+    && cargo install sqlx-cli --version 0.7.3 \
+    && cargo install cargo-llvm-cov --version 0.5.39 \
+    && cargo install cargo-hack --version 0.6.15
 
 #
-# Protobuf tools
+# Buffrs
 #
 RUN : \
     && cargo install buffrs --version 0.7.2 \

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ is built from various Ubuntu starting images.
 | buffrs | cargo | 0.7.2 |
 | build-essential | apt-get | latest |
 | BuildKit | GitHub Releases | 0.12.4 |
-| cargo-deny | cargo | latest |
-| cargo-hack | cargo | latest |
-| cargo-llvm-cov | cargo | latest |
-| cargo-semver-checks | cargo | latest |
+| cargo-deny | cargo | 0.14.3 |
+| cargo-hack | cargo | 0.6.15 |
+| cargo-llvm-cov | cargo | 0.5.39 |
+| cargo-semver-checks | cargo | 0.26.0 |
 | clang | apt-get | latest |
 | cmake | apt-get | latest |
 | cURL | apt-get | latest |
@@ -64,7 +64,7 @@ is built from various Ubuntu starting images.
 | rustfmt | rustup | nightly (additionally) |
 | sccache | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.7.4 |
 | Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.11.1 |
-| sqlx-cli | cargo | latest |
+| sqlx-cli | cargo | 0.7.3 |
 | Terraform | Hashicorp releases | 1.6.6 |
 | wget | apt-get | latest |
 | [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases) | 4.40.5 |

--- a/README.md
+++ b/README.md
@@ -13,61 +13,61 @@ image for continuous integration pipelines. The image is currently base on `ubun
 Aside from the `develop` tag, exact image versions can be pinned based on `git tag --describe`. The Kraken base image
 is built from various Ubuntu starting images.
 
-| Starting Image | Kraken base image tags | Notes |
-| -------------- | ---------------------- | ----- |
-| `ubuntu:20.04` | `develop-ubuntu_20.04`, `x.y.z-ubuntu_20.04`, `x.y-ubuntu_20.04` | |
-| `ubuntu:22.04` | `develop`, `x.y.z`, `x.y`, `develop-ubuntu_22.04`, `x.y.z-ubuntu_22.04`, `x.y-ubuntu_22.04` | |
+| Starting Image | Kraken base image tags                                                                      | Notes |
+|----------------|---------------------------------------------------------------------------------------------|-------|
+| `ubuntu:20.04` | `develop-ubuntu_20.04`, `x.y.z-ubuntu_20.04`, `x.y-ubuntu_20.04`                            |       |
+| `ubuntu:22.04` | `develop`, `x.y.z`, `x.y`, `develop-ubuntu_22.04`, `x.y.z-ubuntu_22.04`, `x.y-ubuntu_22.04` |       |
 
 ## Image contents
 
-| Software | Installed via | Version |
-| -------- | ------------- | ------- |
-| ansible | Pipx (Python 3.10) | 9.1.0 |
-| ansible-base | Pipx (Python 3.10) | 2.10.17 |
-| buf | [GitHub releases](https://github.com/bufbuild/buf/releases) | 1.17.0 |
-| buffrs | cargo | 0.7.2 |
-| build-essential | apt-get | latest |
-| BuildKit | GitHub Releases | 0.12.4 |
-| cargo-deny | cargo | 0.14.3 |
-| cargo-hack | cargo | 0.6.15 |
-| cargo-llvm-cov | cargo | 0.5.39 |
-| cargo-semver-checks | cargo | 0.26.0 |
-| clang | apt-get | latest |
-| cmake | apt-get | latest |
-| cURL | apt-get | latest |
-| Docker | apt-get (`docker.io` package) | latest |
-| Docker Buildx | DockerHub | latest |
-| gcc, g++ | apt-get | latest |
-| Git | apt-get | latest |
-| Git LFS | apt-get | latest |
-| GraphViz | apt-get | latest |
-| grcov | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py)) | 0.8.19 |
-| jq | apt-get | latest |
-| Helm | get-helm-3 | latest |
-| kraken-wrapper | Pipx (Python 3.10) | 0.32.4 |
-| Kubectl | apt-get (`apt.kubernetes.io`) | 1.28.4 |
-| lcov | apt-get | latest
-| libffi | apt-get | latest |
-| libssl | apt-get | latest |
-| llvm | apt-get | latest |
-| manifest-tool | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py)) | 2.1.5 |
-| Nix | `https://nixos.org/nix/install` | latest |
-| NodeJS | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall)) | 18 |
-| PDM | Pipx (Python 3.10) | 2.11.1 |
-| Pipx | Pip (Python 3.10) | 1.3.3 |
-| pkg-config | apt-get | latest |
-| Poetry | Pipx (Python 3.10) | 1.7.1 |
-| protobuf-compiler | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1 |
-| Python | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) | 3.8, 3.9, 3.10 <sup>default</sup>, 3.11, 3.12 |
-| Rust / Cargo | Rustup | 1.73.0 / 0.73.0 |
-| Rustup | rustup.rs | latest |
-| rustfmt | rustup | nightly (additionally) |
-| sccache | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.7.4 |
-| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.11.1 |
-| sqlx-cli | cargo | 0.7.3 |
-| Terraform | Hashicorp releases | 1.6.6 |
-| wget | apt-get | latest |
-| [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases) | 4.40.5 |
+| Software                                               | Installed via                                                                                                      | Version                                       |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| ansible                                                | Pipx (Python 3.10)                                                                                                 | 9.1.0                                         |
+| ansible-base                                           | Pipx (Python 3.10)                                                                                                 | 2.10.17                                       |
+| buf                                                    | [GitHub releases](https://github.com/bufbuild/buf/releases)                                                        | 1.17.0                                        |
+| buffrs                                                 | cargo                                                                                                              | 0.7.2                                         |
+| build-essential                                        | apt-get                                                                                                            | latest                                        |
+| BuildKit                                               | GitHub Releases                                                                                                    | 0.12.4                                        |
+| cargo-deny                                             | cargo                                                                                                              | 0.14.3                                        |
+| cargo-hack                                             | cargo                                                                                                              | 0.6.15                                        |
+| cargo-llvm-cov                                         | cargo                                                                                                              | 0.5.39                                        |
+| cargo-semver-checks                                    | cargo                                                                                                              | 0.26.0                                        |
+| clang                                                  | apt-get                                                                                                            | latest                                        |
+| cmake                                                  | apt-get                                                                                                            | latest                                        |
+| cURL                                                   | apt-get                                                                                                            | latest                                        |
+| Docker                                                 | apt-get (`docker.io` package)                                                                                      | latest                                        |
+| Docker Buildx                                          | DockerHub                                                                                                          | latest                                        |
+| gcc, g++                                               | apt-get                                                                                                            | latest                                        |
+| Git                                                    | apt-get                                                                                                            | latest                                        |
+| Git LFS                                                | apt-get                                                                                                            | latest                                        |
+| GraphViz                                               | apt-get                                                                                                            | latest                                        |
+| grcov                                                  | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py))                        | 0.8.19                                        |
+| jq                                                     | apt-get                                                                                                            | latest                                        |
+| Helm                                                   | get-helm-3                                                                                                         | latest                                        |
+| kraken-wrapper                                         | Pipx (Python 3.10)                                                                                                 | 0.32.4                                        |
+| Kubectl                                                | apt-get (`apt.kubernetes.io`)                                                                                      | 1.28.4                                        |
+| lcov                                                   | apt-get                                                                                                            | latest                                        |
+| libffi                                                 | apt-get                                                                                                            | latest                                        |
+| libssl                                                 | apt-get                                                                                                            | latest                                        |
+| llvm                                                   | apt-get                                                                                                            | latest                                        |
+| manifest-tool                                          | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py))         | 2.1.5                                         |
+| Nix                                                    | `https://nixos.org/nix/install`                                                                                    | latest                                        |
+| NodeJS                                                 | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall))                         | 18                                            |
+| PDM                                                    | Pipx (Python 3.10)                                                                                                 | 2.11.1                                        |
+| Pipx                                                   | Pip (Python 3.10)                                                                                                  | 1.3.3                                         |
+| pkg-config                                             | apt-get                                                                                                            | latest                                        |
+| Poetry                                                 | Pipx (Python 3.10)                                                                                                 | 1.7.1                                         |
+| protobuf-compiler                                      | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1                                        |
+| Python                                                 | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)                                        | 3.8, 3.9, 3.10 <sup>default</sup>, 3.11, 3.12 |
+| Rust / Cargo                                           | Rustup                                                                                                             | 1.73.0                                        |
+| Rustup                                                 | rustup.rs                                                                                                          | latest                                        |
+| rustfmt                                                | rustup                                                                                                             | nightly (additionally)                        |
+| sccache                                                | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py))                    | 0.7.4                                         |
+| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10)                                                                                                 | 1.11.1                                        |
+| sqlx-cli                                               | cargo                                                                                                              | 0.7.3                                         |
+| Terraform                                              | Hashicorp releases                                                                                                 | 1.6.6                                         |
+| wget                                                   | apt-get                                                                                                            | latest                                        |
+| [yq](https://mikefarah.gitbook.io/yq/)                 | [GitHub releases](https://github.com/mikefarah/yq/releases)                                                        | 4.40.5                                        |
 
 __Footnotes__
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ is built from various Ubuntu starting images.
 | pkg-config | apt-get | latest |
 | Poetry | Pipx (Python 3.10) | 1.7.1 |
 | protobuf-compiler | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1 |
-| proxy.py | Pipx (Python 3.10) | 2.4.3 |
-| pyenv | [pyenv-installer](https://github.com/pyenv/pyenv-installer) | latest |
 | Python | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) | 3.8, 3.9, 3.10 <sup>default</sup>, 3.11, 3.12 |
 | Rust / Cargo | Rustup | 1.73.0 / 0.73.0 |
 | Rustup | rustup.rs | latest |
@@ -69,7 +67,7 @@ is built from various Ubuntu starting images.
 | sqlx-cli | cargo | latest |
 | Terraform | Hashicorp releases | 1.6.6 |
 | wget | apt-get | latest |
-| [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases) | 4.30.1 |
+| [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases) | 4.40.5 |
 
 __Footnotes__
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ is built from various Ubuntu starting images.
 
 | Starting Image | Kraken base image tags | Notes |
 | -------------- | ---------------------- | ----- |
-| `ubuntu:18.04` | `develop-ubuntu_18.04`, `x.y.z-ubuntu_18.04` | EOL -- Do not use anymore |
 | `ubuntu:20.04` | `develop-ubuntu_20.04`, `x.y.z-ubuntu_20.04`, `x.y-ubuntu_20.04` | |
 | `ubuntu:22.04` | `develop`, `x.y.z`, `x.y`, `develop-ubuntu_22.04`, `x.y.z-ubuntu_22.04`, `x.y-ubuntu_22.04` | |
 
@@ -23,12 +22,12 @@ is built from various Ubuntu starting images.
 
 | Software | Installed via | Version |
 | -------- | ------------- | ------- |
-| ansible | Pipx (Python 3.10) | 8.1.0 |
+| ansible | Pipx (Python 3.10) | 9.1.0 |
 | ansible-base | Pipx (Python 3.10) | 2.10.17 |
 | buf | [GitHub releases](https://github.com/bufbuild/buf/releases) | 1.17.0 |
 | buffrs | cargo | 0.7.2 |
 | build-essential | apt-get | latest |
-| BuildKit | GitHub Releases | 0.12.2 |
+| BuildKit | GitHub Releases | 0.12.4 |
 | cargo-deny | cargo | latest |
 | cargo-hack | cargo | latest |
 | cargo-llvm-cov | cargo | latest |
@@ -42,31 +41,31 @@ is built from various Ubuntu starting images.
 | Git | apt-get | latest |
 | Git LFS | apt-get | latest |
 | GraphViz | apt-get | latest |
-| grcov | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py)) | 0.8.11 |
+| grcov | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py)) | 0.8.19 |
 | jq | apt-get | latest |
 | Helm | get-helm-3 | latest |
 | kraken-wrapper | Pipx (Python 3.10) | 0.32.4 |
-| Kubectl | apt-get (`apt.kubernetes.io`) | latest |
+| Kubectl | apt-get (`apt.kubernetes.io`) | 1.28.4 |
 | lcov | apt-get | latest
 | libffi | apt-get | latest |
 | libssl | apt-get | latest |
 | llvm | apt-get | latest |
-| manifest-tool | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py)) | 2.0.5 |
+| manifest-tool | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py)) | 2.1.5 |
 | Nix | `https://nixos.org/nix/install` | latest |
-| NodeJS | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall)) | 16 on `ubuntu:18.04`, 18 elsewhere |
-| PDM | Pipx (Python 3.10) | 2.8.2 |
-| Pipx | Pip (Python 3.10) | latest |
+| NodeJS | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall)) | 18 |
+| PDM | Pipx (Python 3.10) | 2.11.1 |
+| Pipx | Pip (Python 3.10) | 1.3.3 |
 | pkg-config | apt-get | latest |
-| Poetry | Pipx (Python 3.10) | 1.6.0 |
+| Poetry | Pipx (Python 3.10) | 1.7.1 |
 | protobuf-compiler | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1 |
 | proxy.py | Pipx (Python 3.10) | 2.4.3 |
 | pyenv | [pyenv-installer](https://github.com/pyenv/pyenv-installer) | latest |
-| Python | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) | 3.6 <sup>1)</sup>, 3.7, 3.8, 3.9, 3.10 <sup>default</sup>, 3.11 |
+| Python | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) | 3.8, 3.9, 3.10 <sup>default</sup>, 3.11, 3.12 |
 | Rust / Cargo | Rustup | 1.73.0 / 0.73.0 |
 | Rustup | rustup.rs | latest |
 | rustfmt | rustup | nightly (additionally) |
-| sccache | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.5.2 |
-| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.10.3 |
+| sccache | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.7.4 |
+| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10) | 1.11.1 |
 | sqlx-cli | cargo | latest |
 | Terraform | Hashicorp releases | 1.6.6 |
 | wget | apt-get | latest |

--- a/formulae/buildkit.py
+++ b/formulae/buildkit.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class BuildkitFormula(BinaryInstallFormula):
 
-    version = "0.12.2"
+    version = "0.12.4"
     archive_url = "https://github.com/moby/buildkit/releases/download/v${version}/buildkit-v${version}.linux-${archv2}.tar.gz"
     archive_members = ["bin/*"]
     install_to = "/usr/local/bin"

--- a/formulae/grcov.py
+++ b/formulae/grcov.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 class GrcovFormula(BinaryInstallFormula):
 
     platform = {"linux": "unknown-linux-gnu", "darwin": "apple-darwin"}[sys.platform]
-    version = "0.8.11"
+    version = "0.8.19"
     archive_url = "https://github.com/mozilla/grcov/releases/download/v${version}/grcov-${archv1}-${platform}.tar.bz2"
     archive_members = ["grcov"]
     install_to = "/usr/local/bin"

--- a/formulae/kubectl.py
+++ b/formulae/kubectl.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class KubectlFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "v1.25.3"
+    version = "v1.28.4"
     download_url = "https://dl.k8s.io/release/${version}/bin/${platform}/${archv2}/kubectl"
     chmod = 0o775
     output_directory = "${install_to}"

--- a/formulae/manifest-tool.py
+++ b/formulae/manifest-tool.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 
 class ManifestToolFormula(BinaryInstallFormula):
 
-    version = "2.0.5"
+    version = "2.1.5"
     archive_url = (
         "https://github.com/estesp/manifest-tool/releases/download/v${version}/"
         "binaries-manifest-tool-${version}.tar.gz"

--- a/formulae/sccache.py
+++ b/formulae/sccache.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 class SccacheFormula(BinaryInstallFormula):
 
     platform = {"linux": "unknown-linux-musl", "darwin": "apple-darwin"}[sys.platform]
-    version = "0.5.3"
+    version = "0.7.4"
     archive_url = "https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-${archv1}-${platform}.tar.gz"
     archive_members = ["sccache-v${version}-${archv1}-${platform}/sccache"]
     install_to = "/usr/local/bin"

--- a/formulae/yq.py
+++ b/formulae/yq.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class YqFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "4.30.1"
+    version = "4.40.5"
     download_url = "https://github.com/mikefarah/yq/releases/download/v${version}/yq_${platform}_${archv2}"
     chmod = 0o775
     output_file = "${install_to}/yq"


### PR DESCRIPTION
* Remove Python 3.6 specific code (does not apply to Ubuntu 22/20 images)
* Remove Pyenv
* Remove proxy.py
* Remove any mention of Ubuntu 18 support
* Add Python 3.12
* Pin Pipx to 1.3.3
* Pin cargo-deny 0.14.3
* Pin cargo-semver-checks 0.26.0
* Pin sqlx-cli 0.7.3
* Pin cargo-llvm-cov 0.5.39
* Pin cargo-hack 0.6.15
* Upgrade Poetry 1.6.0 &rarr; 1.7.1
* Upgrade PDM 2.8.2 &rarr; 2.11.1
* Upgrade Slap 1.10.3 &rarr; 1.11.1
* Upgrade Ansible 8.1.0 &rarr; 9.1.0
* Upgrade BuildKit 0.12.2 &rarr; 0.12.4
* Upgrade Grcov 0.8.11 &rarr; 0.8.19
* Upgrade kubectl 1.25.3 &rarr; 1.28.4
* Upgrade manifest-tool 2.0.5 &rarr; 2.1.5
* Upgrade sccache 0.5.2 &rarr; 0.7.4
* Upgrade yq 4.30.1 &rarr; 4.40.5

__Also in this PR__

* Build Cargo binaries with sccache cached to GHA