### PR TITLE
[1.7.x] Set Rust toolchain 1.73.0 as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN : \
     && cargo install cargo-llvm-cov \
     && cargo install cargo-hack \
     && rustup toolchain install 1.73.0 \
+    && rustup default 1.73.0 \
     && rustup component add rustfmt --toolchain 1.73.0
 
 #


### PR DESCRIPTION
We didn't set 1.73.0 as the default Rust toolchain