### PR TITLE
Install all tools system-wide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,8 @@ RUN : \
 #
 # Python tools
 #
+RUN mkdir -p /opt/pipx
+ENV PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin
 RUN : \
     && python -m pip install pipx==1.3.3 -v \
     && pipx install poetry==1.7.1 \


### PR DESCRIPTION
This is experimental. The end goal is that we can use the base image for our Coder workspaces. Installed tools need to be usable by a non-root user in that case, but we rely on `root` in CI.