### PR TITLE
Upgrades all around

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,9 +84,9 @@ COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/doc
 #
 ARG ACTIONS_CACHE_URL
 RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
-    && rustup toolchain install 1.77.0 \
+    && rustup toolchain install 1.78.0 \
     && rustup toolchain install nightly --component rustfmt \
-    && rustup default 1.77.0 \
+    && rustup default 1.78.0 \
     #&& ( \
     #    SCCACHE_GHA_ENABLED=true \
     #    ACTIONS_CACHE_URL=$ACTIONS_CACHE_URL \
@@ -95,12 +95,12 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     #) \
     && sccache --start-server \
     && export RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 \
-    && cargo install cargo-deny --version 0.14.20 \
-    && cargo install cargo-semver-checks --version 0.26.0 \
-    && cargo install sqlx-cli --version 0.7.3 \
-    && cargo install cargo-llvm-cov --version 0.5.39 \
-    && cargo install cargo-hack --version 0.6.15 \
-    && cargo install buffrs --version 0.8.0 \
+    && cargo install cargo-deny --version 0.14.24 \
+    && cargo install cargo-semver-checks --version 0.31.0 \
+    && cargo install sqlx-cli --version 0.7.4 \
+    && cargo install cargo-llvm-cov --version 0.6.10 \
+    && cargo install cargo-hack --version 0.6.28 \
+    && cargo install buffrs --version 0.8.1 \
     && sccache --stop-server
 
 #
@@ -108,7 +108,7 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
 #
 RUN : \
     && BIN="/usr/bin"  \
-    && VERSION="1.17.0"  \
+    && VERSION="1.32.2"  \
     && curl -sSL \
     "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
     -o "${BIN}/buf" && \
@@ -118,13 +118,13 @@ RUN : \
 # Python tools
 #
 RUN : \
-    && python -m pip install pipx==1.3.3 -v \
+    && python -m pip install pipx==1.6.0 -v \
     && pipx install poetry==1.8.3 \
-    && pipx install pdm==2.12.1 \
-    && pipx install slap-cli==1.12.0 \
-    && pipx install kraken-wrapper==0.34.1 \
-    && pipx install uv==0.1.1 \
-    && pipx install ansible-base==2.10.17 && pipx inject ansible-base ansible==9.2.0 \
+    && pipx install pdm==2.15.4 \
+    && pipx install slap-cli==1.14.1 \
+    && pipx install kraken-wrapper==0.36.8 \
+    && pipx install uv==0.2.10 \
+    && pipx install ansible==9.6.1 --include-deps \
     && rm -rf ~/.cache/pip
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN --mount=type=bind,src=formulae,target=/tmp/formulae \
     # install from custom formulae
     #
     && python /tmp/src/main.py /tmp/formulae/argocd.py \
+    && python /tmp/src/main.py /tmp/formulae/buf.py \
     && python /tmp/src/main.py /tmp/formulae/buildkit.py \
     && python /tmp/src/main.py /tmp/formulae/cni.py \
     && python /tmp/src/main.py /tmp/formulae/cri-dockerd.py \
@@ -102,17 +103,6 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     && cargo install cargo-hack --version 0.6.28 \
     && cargo install buffrs --version 0.8.1 \
     && sccache --stop-server
-
-#
-# Buf
-#
-RUN : \
-    && BIN="/usr/bin"  \
-    && VERSION="1.32.2"  \
-    && curl -sSL \
-    "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
-    -o "${BIN}/buf" && \
-    chmod +x "${BIN}/buf"
 
 #
 # Python tools

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ the base image in that minor version range besides a higher minor having already
 
 | Software                               | Installed via                                                                                   | Version |
 |----------------------------------------|-------------------------------------------------------------------------------------------------|---------|
-| ansible                                | Pipx (Python 3.10)                                                                              | 9.2.0   |
-| ansible-base                           | Pipx (Python 3.10)                                                                              | 2.10.17 |
+| ansible                                | Pipx (Python 3.10)                                                                              | 9.6.1   |
 | build-essential                        | apt-get                                                                                         | latest  |
-| BuildKit                               | GitHub Releases                                                                                 | 0.12.4  |
+| BuildKit                               | GitHub Releases                                                                                 | 0.13.2  |
 | clang                                  | apt-get                                                                                         | latest  |
 | cloud-utils                            | apt-get                                                                                         | latest  |
 | cURL                                   | apt-get                                                                                         | latest  |
@@ -44,27 +43,27 @@ the base image in that minor version range besides a higher minor having already
 | Git LFS                                | apt-get                                                                                         | latest  |
 | GraphViz                               | apt-get                                                                                         | latest  |
 | jq                                     | apt-get                                                                                         | latest  |
-| kraken-wrapper                         | Pipx (Python 3.10)                                                                              | 0.34.1  |
+| kraken-wrapper                         | Pipx (Python 3.10)                                                                              | 0.36.8  |
 | libffi                                 | apt-get                                                                                         | latest  |
 | libssl                                 | apt-get                                                                                         | latest  |
 | openssh-client                         | apt-get                                                                                         | latest  |
 | pkg-config                             | apt-get                                                                                         | latest  |
 | QEMU (kvm, x86_64, aarch64)            | apt-get                                                                                         | latest  |
-| sccache                                | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.7.4   |
-| sqlx-cli                               | cargo                                                                                           | 0.7.3   |
+| sccache                                | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.8.1   |
+| sqlx-cli                               | cargo                                                                                           | 0.7.4   |
 | wget                                   | apt-get                                                                                         | latest  |
-| [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases)                                     | 4.40.5  |
+| [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases)                                     | 4.44.1  |
 
 ### Language runtimese and tools
 
 | Software                                               | Installed via                                                                                                      | Version                                       |
 |--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| buf                                                    | [GitHub releases](https://github.com/bufbuild/buf/releases)                                                        | 1.17.0                                        |
-| buffrs                                                 | cargo                                                                                                              | 0.8.0                                         |
-| cargo-deny                                             | cargo                                                                                                              | 0.14.20                                       |
-| cargo-hack                                             | cargo                                                                                                              | 0.6.15                                        |
-| cargo-llvm-cov                                         | cargo                                                                                                              | 0.5.39                                        |
-| cargo-semver-checks                                    | cargo                                                                                                              | 0.26.0                                        |
+| buf                                                    | [GitHub releases](https://github.com/bufbuild/buf/releases)                                                        | 1.32.2                                        |
+| buffrs                                                 | cargo                                                                                                              | 0.8.1                                         |
+| cargo-deny                                             | cargo                                                                                                              | 0.14.24                                       |
+| cargo-hack                                             | cargo                                                                                                              | 0.6.28                                        |
+| cargo-llvm-cov                                         | cargo                                                                                                              | 0.6.10                                        |
+| cargo-semver-checks                                    | cargo                                                                                                              | 0.31.0                                        |
 | cmake                                                  | apt-get                                                                                                            | latest                                        |
 | gcc, g++                                               | apt-get                                                                                                            | latest                                        |
 | grcov                                                  | [GitHub releases](https://github.com/mozilla/grcov/releases) ([formula](formulae/grcov.py))                        | 0.8.19                                        |
@@ -72,17 +71,17 @@ the base image in that minor version range besides a higher minor having already
 | llvm                                                   | apt-get                                                                                                            | latest                                        |
 | Nix                                                    | `https://nixos.org/nix/install`                                                                                    | latest                                        |
 | NodeJS                                                 | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall))                         | 18                                            |
-| PDM                                                    | Pipx (Python 3.10)                                                                                                 | 2.11.1                                        |
-| Pipx                                                   | Pip (Python 3.10)                                                                                                  | 1.3.3                                         |
+| PDM                                                    | Pipx (Python 3.10)                                                                                                 | 2.15.4                                        |
+| Pipx                                                   | Pip (Python 3.10)                                                                                                  | 1.6.0                                         |
 | Poetry                                                 | Pipx (Python 3.10)                                                                                                 | 1.8.3                                         |
 | protobuf-compiler                                      | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.1                                        |
 | Python                                                 | [ppa:deadsnakes/ppa](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)                                        | 3.8, 3.9, 3.10 <sup>default</sup>, 3.11, 3.12 |
-| Rust / Cargo                                           | Rustup                                                                                                             | 1.77.0                                        |
+| Rust / Cargo                                           | Rustup                                                                                                             | 1.78.0                                        |
 | rustfmt                                                | rustup                                                                                                             | nightly (additionally)                        |
 | Rustup                                                 | rustup.rs                                                                                                          | latest                                        |
-| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10)                                                                                                 | 1.12.0                                        |
-| Terraform                                              | Hashicorp releases                                                                                                 | 1.6.6                                         |
-| [uv](https://astral.sh/blog/uv)                        | Pipx                                                                                                               | 0.1.1                                         |
+| Slap ([link](https://github.com/python-slap/slap-cli)) | Pipx (Python 3.10)                                                                                                 | 1.14.1                                        |
+| Terraform                                              | Hashicorp releases                                                                                                 | 1.8.5                                         |
+| [uv](https://astral.sh/blog/uv)                        | Pipx                                                                                                               | 0.2.10                                        |
 
 ### Container tools
 
@@ -90,21 +89,21 @@ the base image in that minor version range besides a higher minor having already
 |---------------|------------------------------------------------------------------------------------------------------------|---------|
 | Docker        | apt-get (`docker.io` package)                                                                              | latest  |
 | Docker Buildx | DockerHub                                                                                                  | latest  |
-| manifest-tool | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py)) | 2.1.5   |
+| manifest-tool | [GitHub releases](https://github.com/estesp/manifest-tool/releases) ([formula](formulae/manifest-tool.py)) | 2.1.6   |
 
 ### Kubernetes
 
 | Software                                | Installed via                                                                                 | Version |
 |-----------------------------------------|-----------------------------------------------------------------------------------------------|---------|
-| argocd (CLI)                            | [GitHub releases](https://github.com/argoproj/argo-cd/releases)                               | 2.10.2  |
+| argocd (CLI)                            | [GitHub releases](https://github.com/argoproj/argo-cd/releases)                               | 2.11.3  |
 | conntrack                               | apt-get                                                                                       | latest  |
-| ContainerNetworkingPlugins (CNI)        | [GitHub releases](https://github.com/containernetworking/plugins/releases)                    | v1.4.0  |
-| cri-dockerd                             | [GitHub releases](https://github.com/Mirantis/cri-dockerd/releases)                           | v0.3.10 |
-| crictl                                  | [GitHub releases](https://github.com/kubernetes-sigs/cri-tools/releases)                      | v1.29.0 |
+| ContainerNetworkingPlugins (CNI)        | [GitHub releases](https://github.com/containernetworking/plugins/releases)                    | 1.5.0   |
+| cri-dockerd                             | [GitHub releases](https://github.com/Mirantis/cri-dockerd/releases)                           | 0.3.14  |
+| crictl                                  | [GitHub releases](https://github.com/kubernetes-sigs/cri-tools/releases)                      | 1.30.0  |
 | Helm                                    | get-helm-3                                                                                    | latest  |
-| kubectl                                 | apt-get (`apt.kubernetes.io`)                                                                 | 1.28.4  |
-| minikube                                | `storage.googleapis.com/minikube/releases` ([docs](https://minikube.sigs.k8s.io/docs/start/)) | v1.32.0 |
-| [stern](https://github.com/stern/stern) | [GitHub releases](https://github.com/stern/stern/releases/)                                   | v1.28.0 |
+| kubectl                                 | apt-get (`apt.kubernetes.io`)                                                                 | 1.30.1  |
+| minikube                                | `storage.googleapis.com/minikube/releases` ([docs](https://minikube.sigs.k8s.io/docs/start/)) | 1.33.1  |
+| [stern](https://github.com/stern/stern) | [GitHub releases](https://github.com/stern/stern/releases/)                                   | 1.30.0  |
 
 ## Developemnt
 

--- a/formulae/argocd.py
+++ b/formulae/argocd.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class ArgocdFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "v2.10.2"
+    version = "v2.11.3"
     download_url = "https://github.com/argoproj/argo-cd/releases/download/${version}/argocd-linux-${archv2}"
     chmod = 0o775
     output_directory = "${install_to}"

--- a/formulae/buf.py
+++ b/formulae/buf.py
@@ -1,0 +1,13 @@
+import sys
+
+from formula import DownloadFileFormula
+
+
+class BufFormula(DownloadFileFormula):
+
+    platform = sys.platform.capitalize()
+    version = "1.32.2"
+    download_url = "https://github.com/bufbuild/buf/releases/download/v${version}/buf-${platform}-${archv1}"
+    chmod = 0o775
+    output_directory = "${install_to}"
+    install_to = "/usr/local/bin"

--- a/formulae/buildkit.py
+++ b/formulae/buildkit.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class BuildkitFormula(BinaryInstallFormula):
 
-    version = "0.12.4"
+    version = "0.13.2"
     archive_url = "https://github.com/moby/buildkit/releases/download/v${version}/buildkit-v${version}.linux-${archv2}.tar.gz"
     archive_members = ["bin/*"]
     install_to = "/usr/local/bin"

--- a/formulae/cni.py
+++ b/formulae/cni.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class CniFormula(BinaryInstallFormula):
 
-    version = "v1.4.0"
+    version = "v1.5.0"
     archive_url = "https://github.com/containernetworking/plugins/releases/download/${version}/cni-plugins-linux-${archv2}-${version}.tgz"
     archive_members = ["*"]
     install_to = "/opt/cni/bin"

--- a/formulae/cri-dockerd.py
+++ b/formulae/cri-dockerd.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class CriDockerdFormula(BinaryInstallFormula):
 
-    version = "0.3.10"
+    version = "0.3.14"
     archive_url = "https://github.com/Mirantis/cri-dockerd/releases/download/v${version}/cri-dockerd-${version}.amd64.tgz"
     archive_members = ["cri-dockerd/cri-dockerd"]
     install_to = "/usr/local/bin"

--- a/formulae/crictl.py
+++ b/formulae/crictl.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class CrictlFormula(BinaryInstallFormula):
 
-    version = "v1.29.0"
+    version = "v1.30.0"
     archive_url = "https://github.com/kubernetes-sigs/cri-tools/releases/download/${version}/crictl-${version}-linux-amd64.tar.gz"
     archive_members = ["crictl"]
     install_to = "/usr/local/bin"

--- a/formulae/kubectl.py
+++ b/formulae/kubectl.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class KubectlFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "v1.28.4"
+    version = "v1.30.1"
     download_url = "https://dl.k8s.io/release/${version}/bin/${platform}/${archv2}/kubectl"
     chmod = 0o775
     output_directory = "${install_to}"

--- a/formulae/manifest-tool.py
+++ b/formulae/manifest-tool.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 
 class ManifestToolFormula(BinaryInstallFormula):
 
-    version = "2.1.5"
+    version = "2.1.6"
     archive_url = (
         "https://github.com/estesp/manifest-tool/releases/download/v${version}/"
         "binaries-manifest-tool-${version}.tar.gz"

--- a/formulae/minikube.py
+++ b/formulae/minikube.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class MinikubeFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "v1.32.0"
+    version = "v1.33.1"
     download_url = "https://storage.googleapis.com/minikube/releases/${version}/minikube-linux-${archv2}"
     chmod = 0o775
     output_directory = "${install_to}"

--- a/formulae/sccache.py
+++ b/formulae/sccache.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 class SccacheFormula(BinaryInstallFormula):
 
     platform = {"linux": "unknown-linux-musl", "darwin": "apple-darwin"}[sys.platform]
-    version = "0.7.4"
+    version = "0.8.1"
     archive_url = "https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-${archv1}-${platform}.tar.gz"
     archive_members = ["sccache-v${version}-${archv1}-${platform}/sccache"]
     install_to = "/usr/local/bin"

--- a/formulae/stern.py
+++ b/formulae/stern.py
@@ -3,7 +3,7 @@ from formula import BinaryInstallFormula
 
 class SternFormula(BinaryInstallFormula):
 
-    version = "1.28.0"
+    version = "1.30.0"
     archive_url = "https://github.com/stern/stern/releases/download/v${version}/stern_${version}_linux_${archv2}.tar.gz"
     archive_members = ["stern"]
     install_to = "/usr/local/bin"

--- a/formulae/terraform.py
+++ b/formulae/terraform.py
@@ -6,7 +6,7 @@ from formula import BinaryInstallFormula
 class TerraformFormula(BinaryInstallFormula):
 
     platform = {"linux": "unknown-linux-musl", "darwin": "apple-darwin"}[sys.platform]
-    version = "1.6.6"
+    version = "1.8.5"
     archive_url = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${archv2}.zip"
     archive_members = ["terraform"]
     install_to = "/usr/local/bin"

--- a/formulae/yq.py
+++ b/formulae/yq.py
@@ -6,7 +6,7 @@ from formula import DownloadFileFormula
 class YqFormula(DownloadFileFormula):
 
     platform = sys.platform
-    version = "4.40.5"
+    version = "4.44.1"
     download_url = "https://github.com/mikefarah/yq/releases/download/v${version}/yq_${platform}_${archv2}"
     chmod = 0o775
     output_file = "${install_to}/yq"


### PR DESCRIPTION

* ansible 9.2.0 &rarr; 9.6.1
* argocd 2.10.2 &rarr; 2.11.3
* buf 1.17.0 &rarr; 1.32.2
* buffrs 0.8.0 &rarr; 0.8.1
* BuildKit 0.12.4 &rarr; 0.13.2
* cargo-deny 1.14.20 &rarr; 0.14.24
* cargo-llvm-cov 0.5.39 &rarr; 0.6.10
* cargo-semver-checks 0.26.0 &rarr; 0.31.0
* CNI plugins 1.4.0 &rarr; 1.5.0
* cri-dockerd 0.3.10 &rarr; 0.3.14
* crictl 1.29.0 &rarr; 1.30.0
* kraken-wrapper 0.34.1 &rarr; 0.36.8
* kubectl 1.28.4 &rarr; 1.30.1
* manifest-tool 2.1.5 &rarr; 2.1.6
* minikube 1.32.0 &rarr; 1.33.1
* pdm 2.11.1 &rarr; 2.15.4
* pipx 1.3.3 &rarr; 1.6.0
* Rust 1.77.0 &rarr; 1.78.0
* sccache 0.7.4 &rarr; 0.8.1
* slap 1.12.0 &rarr; 1.14.1
* sqlx-cli 0.7.3 &rarr; 0.7.4
* stern 1.28.0 &rarr; 1.30.0
* terraform 1.6.6 &rarr; 1.8.5
* uv 0.1.1 &rarr; 0.2.10
* yq 4.40.5 &rarr; 4.44.1
