### PR TITLE
Optimize binaries with UPX

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install UPX
+        run: sudo apt-get update && sudo apt-get install upx -y
+
       - name: Test Formulae
         run: |
           set -e

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,14 +104,13 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
 # Python tools
 #
 RUN : \
-    && python -m pip install pipx==1.6.0 -v \
-    && pipx install poetry==1.8.3 \
-    && pipx install pdm==2.17.3 \
-    && pipx install slap-cli==1.14.1 \
-    && pipx install kraken-wrapper==0.38.0 \
-    && pipx install uv==0.2.33 \
-    && pipx install ansible==9.8.0 --include-deps \
-    && rm -rf ~/.cache/pip
+    && python -m pip install pipx==1.7.1 uv==0.3.2 -v \
+    && uv tool install poetry==1.8.3 \
+    && uv tool install pdm==2.17.3 \
+    && uv tool install slap-cli==1.14.1 \
+    && uv tool install kraken-wrapper==0.38.0 \
+    && uv tool install ansible==9.8.0 --include-deps \
+    && rm -rf ~/.cache
 
 #
 # Nix

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,8 @@ RUN : \
     && uv tool install pdm==2.17.3 \
     && uv tool install slap-cli==1.14.1 \
     && uv tool install kraken-wrapper==0.38.0 \
-    && uv tool install ansible==9.8.0 --include-deps \
+    # NOTE: Uv does not support --include-deps yet, see https://github.com/astral-sh/uv/issues/6314
+    && pipx tool install ansible==9.8.0 --include-deps \
     && rm -rf ~/.cache
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN --mount=type=bind,src=formulae,target=/tmp/formulae \
     # helm
     #
     && ( curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash ) \
+    && upx `which helm` \
     #
     # [cleanup]
     #

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,15 +87,17 @@ ARG ACTIONS_CACHE_URL
 RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     && rustup toolchain install 1.80.0 \
     && rustup default 1.80.0 \
+    && upx which `rustc` \
+    && upx which `cargo` \
     && export SCCACHE_REDIS_ENDPOINT=redis://redis-headless.sccache:6379 \
     && sccache --start-server \
     && export RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 \
-    && time cargo install cargo-deny --version 0.14.24 --locked \
-    && time cargo install cargo-semver-checks --version 0.33.0 --locked \
-    && time cargo install sqlx-cli --version 0.8.0 --locked \
-    && time cargo install cargo-llvm-cov --version 0.6.11 --locked \
-    && time cargo install cargo-hack --version 0.6.30 --locked \
-    && time cargo install buffrs --version 0.9.0 --locked \
+    && time cargo install cargo-deny --version 0.14.24 --locked && upx `which cargo-deny `\
+    && time cargo install cargo-semver-checks --version 0.33.0 --locked && upx `which cargo-semver-checks` \
+    && time cargo install sqlx-cli --version 0.8.0 --locked && upx `which sqlx-cli` \
+    && time cargo install cargo-llvm-cov --version 0.6.11 --locked && upx `which cargo-llvm-cov` \
+    && time cargo install cargo-hack --version 0.6.30 --locked && upx `which cargo-hack` \
+    && time cargo install buffrs --version 0.9.0 --locked && upx `which buffrs` \
     && sccache --stop-server \
     && du -hd1 /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,8 @@ ARG ACTIONS_CACHE_URL
 RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     && rustup toolchain install 1.80.0 \
     && rustup default 1.80.0 \
-    && upx which `rustc` \
+    # NOTE: Don't UPX rustc as its expected to be invoked many times concurrently, and UPX appears to be hindering
+    #       the OS' ability to not load the same binary into memory multiple times.
     && upx which `cargo` \
     && export SCCACHE_REDIS_ENDPOINT=redis://redis-headless.sccache:6379 \
     && sccache --start-server \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,12 +90,12 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     && export SCCACHE_REDIS_ENDPOINT=redis://redis-headless.sccache:6379 \
     && sccache --start-server \
     && export RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 \
-    && time cargo install cargo-deny --version 0.14.24 \
-    && time cargo install cargo-semver-checks --version 0.33.0 \
-    && time cargo install sqlx-cli --version 0.8.0 \
-    && time cargo install cargo-llvm-cov --version 0.6.11 \
-    && time cargo install cargo-hack --version 0.6.30 \
-    && time cargo install buffrs --version 0.9.0 \
+    && time cargo install cargo-deny --version 0.14.24 --locked \
+    && time cargo install cargo-semver-checks --version 0.33.0 --locked \
+    && time cargo install sqlx-cli --version 0.8.0 --locked \
+    && time cargo install cargo-llvm-cov --version 0.6.11 --locked \
+    && time cargo install cargo-hack --version 0.6.30 --locked \
+    && time cargo install buffrs --version 0.9.0 --locked \
     && sccache --stop-server \
     && du -hd1 /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,18 +87,15 @@ ARG ACTIONS_CACHE_URL
 RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN : \
     && rustup toolchain install 1.80.0 \
     && rustup default 1.80.0 \
-    # NOTE: Don't UPX rustc as its expected to be invoked many times concurrently, and UPX appears to be hindering
-    #       the OS' ability to not load the same binary into memory multiple times.
-    && upx which `cargo` \
     && export SCCACHE_REDIS_ENDPOINT=redis://redis-headless.sccache:6379 \
     && sccache --start-server \
     && export RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 \
-    && time cargo install cargo-deny --version 0.14.24 --locked && upx `which cargo-deny `\
-    && time cargo install cargo-semver-checks --version 0.33.0 --locked && upx `which cargo-semver-checks` \
-    && time cargo install sqlx-cli --version 0.8.0 --locked && upx `which sqlx-cli` \
-    && time cargo install cargo-llvm-cov --version 0.6.11 --locked && upx `which cargo-llvm-cov` \
-    && time cargo install cargo-hack --version 0.6.30 --locked && upx `which cargo-hack` \
-    && time cargo install buffrs --version 0.9.0 --locked && upx `which buffrs` \
+    && time cargo install cargo-deny --version 0.14.24 --locked \
+    && time cargo install cargo-semver-checks --version 0.33.0 --locked \
+    && time cargo install sqlx-cli --version 0.8.0 --locked \
+    && time cargo install cargo-llvm-cov --version 0.6.11 --locked \
+    && time cargo install cargo-hack --version 0.6.30 --locked \
+    && time cargo install buffrs --version 0.9.0 --locked \
     && sccache --stop-server \
     && du -hd1 /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE
 ENV DEBIAN_FRONTEND noninteractive
 RUN : \
     && apt-get update \
-    && apt-get install -y curl git wget libssl-dev libffi-dev llvm clang gcc g++ pkg-config build-essential jq sudo openssh-client conntrack cloud-utils qemu-utils qemu-kvm qemu-system-x86-64 qemu-system-aarch64 \
+    && apt-get install -y curl git wget libssl-dev libffi-dev llvm clang gcc g++ pkg-config build-essential jq sudo openssh-client conntrack cloud-utils qemu-utils qemu-kvm qemu-system-x86-64 qemu-system-aarch64 upx \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Install Python versions with deadsnakes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN : \
     && uv tool install slap-cli==1.14.1 \
     && uv tool install kraken-wrapper==0.38.0 \
     # NOTE: Uv does not support --include-deps yet, see https://github.com/astral-sh/uv/issues/6314
-    && pipx tool install ansible==9.8.0 --include-deps \
+    && pipx install ansible==9.8.0 --include-deps \
     && rm -rf ~/.cache
 
 #

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ the base image in that minor version range besides a higher minor having already
 | QEMU (kvm, x86_64, aarch64)            | apt-get                                                                                         | latest  |
 | sccache                                | [GitHub releases](https://github.com/mozilla/sccache/releases) ([formula](formulae/sccache.py)) | 0.8.1   |
 | sqlx-cli                               | cargo                                                                                           | 0.8.0   |
+| [UPX](https://upx.github.io/)          | apt-get                                                                                         | latest  |
 | wget                                   | apt-get                                                                                         | latest  |
 | [yq](https://mikefarah.gitbook.io/yq/) | [GitHub releases](https://github.com/mikefarah/yq/releases)                                     | 4.44.3  |
 

--- a/formulae/argocd.py
+++ b/formulae/argocd.py
@@ -11,3 +11,4 @@ class ArgocdFormula(DownloadFileFormula):
     chmod = 0o775
     output_directory = "${install_to}"
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/buf.py
+++ b/formulae/buf.py
@@ -11,3 +11,4 @@ class BufFormula(DownloadFileFormula):
     chmod = 0o775
     output_directory = "${install_to}"
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/buf.py
+++ b/formulae/buf.py
@@ -10,5 +10,6 @@ class BufFormula(DownloadFileFormula):
     download_url = "https://github.com/bufbuild/buf/releases/download/v${version}/buf-${platform}-${archv1}"
     chmod = 0o775
     output_directory = "${install_to}"
+    output_file = "${install_to}/buf"
     install_to = "/usr/local/bin"
     upx_optimize = True

--- a/formulae/buildkit.py
+++ b/formulae/buildkit.py
@@ -7,3 +7,4 @@ class BuildkitFormula(BinaryInstallFormula):
     archive_url = "https://github.com/moby/buildkit/releases/download/v${version}/buildkit-v${version}.linux-${archv2}.tar.gz"
     archive_members = ["bin/*"]
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/cni.py
+++ b/formulae/cni.py
@@ -8,3 +8,4 @@ class CniFormula(BinaryInstallFormula):
     archive_members = ["*"]
     install_to = "/opt/cni/bin"
     strip_all_components = False
+    upx_optimize = True

--- a/formulae/cri-dockerd.py
+++ b/formulae/cri-dockerd.py
@@ -7,3 +7,4 @@ class CriDockerdFormula(BinaryInstallFormula):
     archive_url = "https://github.com/Mirantis/cri-dockerd/releases/download/v${version}/cri-dockerd-${version}.amd64.tgz"
     archive_members = ["cri-dockerd/cri-dockerd"]
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/crictl.py
+++ b/formulae/crictl.py
@@ -7,3 +7,4 @@ class CrictlFormula(BinaryInstallFormula):
     archive_url = "https://github.com/kubernetes-sigs/cri-tools/releases/download/${version}/crictl-${version}-linux-amd64.tar.gz"
     archive_members = ["crictl"]
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/grcov.py
+++ b/formulae/grcov.py
@@ -10,3 +10,4 @@ class GrcovFormula(BinaryInstallFormula):
     archive_url = "https://github.com/mozilla/grcov/releases/download/v${version}/grcov-${archv1}-${platform}.tar.bz2"
     archive_members = ["grcov"]
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/kubectl.py
+++ b/formulae/kubectl.py
@@ -11,3 +11,4 @@ class KubectlFormula(DownloadFileFormula):
     chmod = 0o775
     output_directory = "${install_to}"
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/manifest-tool.py
+++ b/formulae/manifest-tool.py
@@ -13,3 +13,4 @@ class ManifestToolFormula(BinaryInstallFormula):
     )
     archive_members = {"manifest-tool-${platform}-${archv2}": "manifest-tool"}
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/minikube.py
+++ b/formulae/minikube.py
@@ -12,3 +12,4 @@ class MinikubeFormula(DownloadFileFormula):
     output_directory = "${install_to}"
     output_file = "${output_directory}/minikube"
     install_to = "/usr/local/bin"
+    upx_optimize = True

--- a/formulae/protobuf-compiler.py
+++ b/formulae/protobuf-compiler.py
@@ -13,3 +13,4 @@ class ProtobufCompilerFormula(UnixPackageFormula):
         "https://github.com/protocolbuffers/protobuf/releases/download/v${version}/"
         "protoc-${version}-${platform}-${arch}.zip"
     )
+    upx_optimize = True

--- a/formulae/terraform.py
+++ b/formulae/terraform.py
@@ -10,6 +10,7 @@ class TerraformFormula(BinaryInstallFormula):
     archive_url = "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_${archv2}.zip"
     archive_members = ["terraform"]
     install_to = "/usr/local/bin"
+    upx_optimize = True
 
     def finalize(self) -> None:
         self.chmod("+x", "${install_to}/terraform")

--- a/src/formula.py
+++ b/src/formula.py
@@ -170,7 +170,7 @@ class BinaryInstallFormula(Formula):
                     with src, output_path.open("wb") as dst:
                         shutil.copyfileobj(src, dst)
                     output_path.chmod(self.mode if self.mode is not None else info.mode)
-                    if self.upx_optimize and os.access(os.X_OK):
+                    if self.upx_optimize and os.access(output_path, os.X_OK):
                         self.log('optimizing binary "%s" with UPX', output_path)
                         upx_optimize(output_path)
 

--- a/src/formula.py
+++ b/src/formula.py
@@ -224,6 +224,7 @@ class DownloadFileFormula(Formula):
     output_directory: str | None = None
     chmod: int | None = None
     install_to: str
+    upx_optimize: bool = False
 
     def install(self) -> None:
         download_url = self._eval_member("download_url")

--- a/src/formula.py
+++ b/src/formula.py
@@ -13,6 +13,7 @@ import posixpath
 import shutil
 import stat
 import string
+import subprocess
 import sys
 import tarfile
 import urllib.request
@@ -119,6 +120,7 @@ class Formula:
     def finalize(self) -> None:
         pass
 
+
 class BinaryInstallFormula(Formula):
 
     archive_type: str | None = None
@@ -126,6 +128,10 @@ class BinaryInstallFormula(Formula):
     archive_members: Sequence[str] | Mapping[str, str]
     install_to: str
     strip_all_components: bool = True
+    mode: int | None = None
+    upx_optimize: bool = False
+
+    _extracted_members: list[str] = []
 
     # Formula
 
@@ -163,7 +169,10 @@ class BinaryInstallFormula(Formula):
                     src, info = archive.get_member(archive_member)
                     with src, output_path.open("wb") as dst:
                         shutil.copyfileobj(src, dst)
-                    output_path.chmod(info.mode)
+                    output_path.chmod(self.mode if self.mode is not None else info.mode)
+                    if self.upx_optimize and os.access(os.X_OK):
+                        self.log('optimizing binary "%s" with UPX', output_path)
+                        upx_optimize(output_path)
 
 
 class UnixPackageFormula(Formula):
@@ -185,6 +194,7 @@ class UnixPackageFormula(Formula):
                     shutil.copyfileobj(src, dst)
                 output_path.chmod(info.mode)
 
+
 @contextlib.contextmanager
 def _read_file_archive(filename: str, fp: BinaryIO) -> Iterator[Archive]:
     archive_type = _file_archive_type(filename)
@@ -195,6 +205,7 @@ def _read_file_archive(filename: str, fp: BinaryIO) -> Iterator[Archive]:
     else:
         raise ValueError(f"invalid archive type: {archive_type!r}")
 
+
 def _file_archive_type(filename: str) -> str:
     suffix1 = Path(filename).suffix
     suffix2 = Path(Path(filename).stem).suffix
@@ -204,6 +215,7 @@ def _file_archive_type(filename: str) -> str:
         return "tar"
     else:
         raise RuntimeError(f"could not determine archive type from {filename!r}")
+
 
 class DownloadFileFormula(Formula):
 
@@ -224,6 +236,7 @@ class DownloadFileFormula(Formula):
         else:
             assert False, "output_file or output_directory must be set"
 
+        self.output_file = output_file
         self.log('fetching file at "%s"', download_url)
         try:
             with urllib.request.urlopen(download_url) as response:
@@ -236,6 +249,11 @@ class DownloadFileFormula(Formula):
         except urllib.error.HTTPError as exc:
             self.log('an unexpected error occurred fetching "%s":\n%s', download_url, exc.read().decode())
             raise
+
+        if self.upx_optimize and os.access(output_file, os.X_OK):
+            self.log('optimizing binary "%s" with UPX', output_file)
+            upx_optimize(output_file)
+
 
 @dataclass
 class ArchiveMemberInfo:
@@ -284,3 +302,7 @@ class ZipArchive(Archive):
 
     def members(self) -> list[str]:
         return [entry.filename for entry in self._zip.infolist() if not entry.filename.endswith('/')] # dirs end with /
+
+
+def upx_optimize(file: str | Path) -> None:
+    subprocess.run(["upx", str(file)], check=True)

--- a/src/formula.py
+++ b/src/formula.py
@@ -179,6 +179,7 @@ class UnixPackageFormula(Formula):
     """ Installs a package that has been split into a typical Unix directory structure, bin/, lib/, include/, etc. """
     archive_url: str
     install_to: str = '/usr/local'
+    upx_optimize: bool = False
 
     def install(self) -> None:
         install_to = self._eval_member('install_to')
@@ -193,6 +194,9 @@ class UnixPackageFormula(Formula):
                 with src, output_path.open("wb") as dst:
                     shutil.copyfileobj(src, dst)
                 output_path.chmod(info.mode)
+                if self.upx_optimize and os.access(output_path, os.X_OK):
+                    self.log('optimizing binary "%s" with UPX', output_path)
+                    upx_optimize(output_path)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Together with the removal of the nightly toolchain in #104 and not installing the default rust toolchain in #105, this reduces the extracted AMD64 image size for the Ubuntu 22 image by approx. 3.3GB.

```
ghcr.io/kraken-build/kraken-base-image/linux/amd64   1.8-22-gb5213c5   382a9e8e65f2   29 minutes ago   6.08GB
ghcr.io/kraken-build/kraken-base-image/linux/amd64   1.8.14            41d62e05154f   2 weeks ago      9.35GB
```

The saving by compressing with UPX alone is approx. 430MB.