### PR TITLE
CI: Migrate from buildjet to Github CI ARM runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
         - arch: amd64
           runs_on: ubuntu-latest
         - arch: arm64
-          runs_on: [buildjet-2vcpu-ubuntu-2204-arm]
+          runs_on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,10 +58,10 @@ jobs:
           runs_on: ubuntu-latest
         - arch: arm64
           base_image: ubuntu_24.04
-          runs_on: [buildjet-4vcpu-ubuntu-2204-arm]
+          runs_on: ubuntu-24.04-arm
         - arch: arm64
           base_image: ubuntu_22.04
-          runs_on: [buildjet-4vcpu-ubuntu-2204-arm]
+          runs_on: ubuntu-24.04-arm
     permissions:
       packages: write
       contents: read

--- a/README.md
+++ b/README.md
@@ -105,10 +105,3 @@ the base image in that minor version range besides a higher minor having already
 | kubectl                                 | apt-get (`apt.kubernetes.io`)                                                                 | 1.30.3  |
 | minikube                                | `storage.googleapis.com/minikube/releases` ([docs](https://minikube.sigs.k8s.io/docs/start/)) | 1.33.1  |
 | [stern](https://github.com/stern/stern) | [GitHub releases](https://github.com/stern/stern/releases/)                                   | 1.30.0  |
-
-## Developemnt
-
-### CI
-
-We use [TestFlows-GitHub-Hetzner-Runners](https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners) on this
-repository.


### PR DESCRIPTION
No need for buildjet anymore