### PR TITLE
Pdm: install on Python 3.12 and upgrade Ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,11 +92,12 @@ RUN --mount=type=secret,id=ACTIONS_RUNTIME_TOKEN \
 RUN : \
     && uv tool install pipx==1.7.1 \
     && uv tool install poetry==2.1.1 \
-    && uv tool install pdm==2.22.3 \
+    # NOTE: Python 3.12 for more lenient certificate validation
+    && uv tool install --python=python3.12 pdm==2.22.3 \
     && uv tool install slap-cli==1.15.0 \
-    && uv tool install kraken-wrapper==0.43.0 \
+    && uv tool install kraken-wrapper==0.43.1 \
     # NOTE: Uv does not support --include-deps yet, see https://github.com/astral-sh/uv/issues/6314
-    && pipx install ansible==11.2.0 --include-deps \
+    && pipx install ansible==11.3.0 --include-deps \
     && rm -rf ~/.cache
 
 #

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the base image in that minor version range besides a higher minor having already
 
 | Software                               | Installed via                                                                                   | Version |
 |----------------------------------------|-------------------------------------------------------------------------------------------------|---------|
-| ansible                                | Pipx (Python 3.12)                                                                              | 11.2.0  |
+| ansible                                | Pipx                                                                                            | 11.3.0  |
 | build-essential                        | apt-get                                                                                         | latest  |
 | BuildKit                               | GitHub Releases                                                                                 | 0.15.1  |
 | clang                                  | apt-get                                                                                         | latest  |
@@ -72,7 +72,7 @@ the base image in that minor version range besides a higher minor having already
 | llvm                                                   | apt-get                                                                                                            | latest                                              |
 | Nix                                                    | `https://nixos.org/nix/install`                                                                                    | latest                                              |
 | NodeJS                                                 | apt-get (via [nodesource install](https://github.com/nodesource/distributions#debinstall))                         | 18                                                  |
-| PDM                                                    | uv                                                                                                                 | 2.22.3                                              |
+| PDM                                                    | uv (Python 3.12)                                                                                                   | 2.22.3                                              |
 | Pipx                                                   | uv                                                                                                                 | 1.6.0                                               |
 | Poetry                                                 | uv                                                                                                                 | 2.1.1                                               |
 | protobuf-compiler                                      | [GitHub releases](https://github.com/protocolbuffers/protobuf/releases) ([formula](formulae/protobuf-compiler.py)) | 3.20.3                                              |


### PR DESCRIPTION
More lenient certificate validation with Python 3.12