### PR TITLE
Update renovate.json to not upgrade buildx above 0.25.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["buildx"],

--- a/renovate.json
+++ b/renovate.json
@@ -3,4 +3,10 @@
   "extends": [
     "config:recommended"
   ]
+  "packageRules": [
+    {
+      "matchPackageNames": ["buildx"],
+      "allowedVersions": "<0.26.0",
+    }
+  ]
 }


### PR DESCRIPTION
buildx 0.26.0 updates [docker to 28.3.2](https://docs.docker.com/engine/release-notes/28/#2830) which includes [#6008](https://github.com/docker/cli/pull/6008) that makes DOCKER_AUTH_CONFIG take precedence over docker login. This issue was addressed in our 1.10.5 fix, but got re-introduced by Renovate when it[ upgraded the version to v0.28.0](https://github.com/kraken-build/kraken-base-image/commit/ee09f4a999b61c298c4384b222ab15023c934d5d). This MR will make sure that now that we have once more downgraded the version, Renovate won't update it again.