### PR TITLE
Bump uv to 0.11.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN : \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 
 # Install UV and Python distributions.
-COPY --from=ghcr.io/astral-sh/uv:0.9.20 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.11 /uv /bin/uv
 RUN : \
     # Install Pip for all other Python versions.
     && set -x \

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ the base image in that minor version range besides a higher minor having already
 | Rustup                                                 | rustup.rs                                                                                                          | latest                                              |
 | Slap ([link](https://github.com/python-slap/slap-cli)) | uv                                                                                                                 | 1.15.0                                              |
 | Terraform                                              | Hashicorp releases                                                                                                 | 1.9.3                                               |
-| [uv](https://astral.sh/blog/uv)                        | docker.io                                                                                                          | 0.9.1                                               |
+| [uv](https://astral.sh/blog/uv)                        | docker.io                                                                                                          | 0.11.11                                             |
 
 ### Container tools
 


### PR DESCRIPTION
We have a project requiring Python 3.13.13 whose [support was only added in uv 0.11.5](https://github.com/astral-sh/uv/releases/tag/0.11.5). I propose to bump uv to the latest version (0.11.11) hoping all the minor Python version would use the latest patch.