### PR TITLE
Add custom Renovate managers to bump uv and kraken-wrapper

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,29 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update uv version copied from the ghcr.io/astral-sh/uv image (Dockerfile and README)",
+      "fileMatch": ["(^|/)Dockerfile$", "(^|/)README\\.md$"],
+      "matchStrings": [
+        "COPY --from=ghcr\\.io/astral-sh/uv:(?<currentValue>[^\\s]+) ",
+        "\\[uv\\]\\([^)]*\\)\\s*\\|\\s*docker\\.io\\s*\\|\\s*(?<currentValue>[0-9][^\\s|]*)"
+      ],
+      "depNameTemplate": "ghcr.io/astral-sh/uv",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kraken-wrapper version installed via uv tool install (Dockerfile and README)",
+      "fileMatch": ["(^|/)Dockerfile$", "(^|/)README\\.md$"],
+      "matchStrings": [
+        "uv tool install kraken-wrapper==(?<currentValue>[^\\s]+)",
+        "\\|\\s*kraken-wrapper\\s*\\|[^|]*\\|\\s*(?<currentValue>[0-9][^\\s|]*)"
+      ],
+      "depNameTemplate": "kraken-wrapper",
+      "datasourceTemplate": "pypi"
+    }
   ]
 }


### PR DESCRIPTION
These will update the uv container image and the kraken-wrapper PyPI package, and update the README.md version references in addition to the installed packages. Validated by running `renovate-config-validator` and `renovate --dry-run` locally.